### PR TITLE
Add value types with exported context

### DIFF
--- a/lib/src/translateProvider.tsx
+++ b/lib/src/translateProvider.tsx
@@ -1,9 +1,11 @@
-import { createContext, h } from 'preact';
+import { Context, createContext, h } from 'preact';
 import { LanguageData } from './languageData';
 import { TranslateOptions } from './translateOptions';
 import useTranslate from './useTranslate';
 
-const TranslateContext = createContext(null);
+const TranslateContext = createContext(null) as Context<
+  ReturnType<typeof useTranslate>
+>;
 
 const defaultOptions: TranslateOptions = {
   root: 'assets',


### PR DESCRIPTION
In its current form using `useContext(TranslateContext)` in a typescript app will just return a value of `any`. This change will include complete types for the context instance and allow me to have complete type safety with any of the return values. (e.g. I would get errors from `t('foo', { value: false })`)

P.S. thanks for putting this little library together, it's exactly what I was looking for!