### PR TITLE
Use stable cache variable on subsequent runs of useTranslate

### DIFF
--- a/lib/src/useTranslate.tsx
+++ b/lib/src/useTranslate.tsx
@@ -17,7 +17,7 @@ export default function useTranslate(
   translations?: LanguageData
 ) {
   options = Object.assign({}, defaultOptions, options);
-  cache = translations || {};
+  cache = translations || cache;
 
   const [lang, setLang] = useState(options.lang);
   const [data, setData] = useState(cache);


### PR DESCRIPTION
Currently when `useTranslate` runs it creates a fresh object for cache each time if `translations` have not been directly provided. However, this causes problems when you need to use fallback lang   since the fallback lang translation object is removed from the cache upon subsequent runs of `useTranslate`. `cache` is already initialized with an empty object value when the `useTranslate` hook is created. It would be better to continue to use this stable value unless `translations` are directly provided.