### PR TITLE
Do not try to fetch translations when key is present on the translations object

### DIFF
--- a/lib/src/useTranslate.tsx
+++ b/lib/src/useTranslate.tsx
@@ -24,7 +24,7 @@ export default function useTranslate(
   const [isReady, setReady] = useState(false);
 
   const loadData = (langKey: string) => {
-    if (data.hasOwnProperty(langKey) && Object.keys(data[langKey]).length > 0) {
+    if (data.hasOwnProperty(langKey)) {
       return;
     }
 


### PR DESCRIPTION
This is especially needed when you don't want to fallback on `en` language.
Because you don't support English yet or don't plan on supporting it.

See #195 