### PR TITLE
Make fallbackLang a param of TranslationProvider

### DIFF
--- a/lib/src/translateProvider.tsx
+++ b/lib/src/translateProvider.tsx
@@ -25,7 +25,7 @@ const TranslateProvider = (props: TranslateProviderProps) => {
     {
       root: props.root || defaultOptions.root,
       lang: props.lang || defaultOptions.lang,
-      fallbackLang: props.lang || defaultOptions.fallbackLang
+      fallbackLang: props.fallbackLang || defaultOptions.fallbackLang
     },
     props.translations
   );

--- a/lib/src/translateProvider.tsx
+++ b/lib/src/translateProvider.tsx
@@ -15,6 +15,7 @@ const defaultOptions: TranslateOptions = {
 export interface TranslateProviderProps {
   root?: string;
   lang?: string;
+  fallbackLang?: string;
   translations?: LanguageData;
   children?: any;
 }
@@ -23,7 +24,8 @@ const TranslateProvider = (props: TranslateProviderProps) => {
   const { t, setLang, lang, isReady } = useTranslate(
     {
       root: props.root || defaultOptions.root,
-      lang: props.lang || defaultOptions.lang
+      lang: props.lang || defaultOptions.lang,
+      fallbackLang: props.lang || defaultOptions.fallbackLang
     },
     props.translations
   );


### PR DESCRIPTION
This is needed when you don't want ti fallback on `en` because you're not supporting this language. This allows you to avoid an `en` key in the `translations` param of `TranslationProvider` object to avoid a `xhr` call.

See #195 
Related #196 