### PR TITLE
Allow sending elements as parameter

### DIFF
--- a/lib/src/translateParams.ts
+++ b/lib/src/translateParams.ts
@@ -1,3 +1,7 @@
-export interface TranslateParams {
-  [key: string]: string | number;
+import { type JSX } from "preact";
+
+export type TranslateParam = string | number | JSX.Element;
+
+export interface TranslateParams<T extends TranslateParam> {
+  [key: string]: T;
 }

--- a/lib/src/useTranslate.tsx
+++ b/lib/src/useTranslate.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'preact/hooks';
 import { LanguageData } from './languageData';
 import { TranslateOptions } from './translateOptions';
-import { TranslateParams } from './translateParams';
+import { type TranslateParam, type TranslateParams } from './translateParams';
 import { format, getResourceUrl, getValue } from './utils';
 
 let cache: LanguageData = {};
@@ -52,7 +52,7 @@ export default function useTranslate(
     loadData(lang);
   }, [lang]);
 
-  const t = (key: string, params?: TranslateParams) => {
+  const t = (key: string, params?: TranslateParams<TranslateParam>) => {
     // eslint-disable-next-line no-prototype-builtins
     if (!data.hasOwnProperty(lang)) {
       return key;


### PR DESCRIPTION
Firstly thank you for your work !

I started using your library however there is one feature which I needed and was not covered by your library which is to allow using elements as params to the translation function. This may be needed when someone wants to have elements like inputs in the end result for example.

It may already already be achieved by just splitting the translation string into multiple strings like `Delete {user}'s {object}` would become `Delete ` and `'s` however this is not practical and you would most likely end up in awkward translations since the order of words changes depending on the language.
For example in french one way to say it would be `Supprime le {object} de {user}`, literally `Delete the {object} of {user}`, correct english but the unnecessary "of" preposition adds to wordiness.
(there are probably better examples)

One way I found to do it without breaking existing uses of the library would be to keep the current code and make the function return a string if there is no object (read JSX.Element) in the params, else it returns an array that may contain strings, numbers or JSX.Element.
I don't know much about (p)react or typescript since I am quite new to both, so there may be better ways to do it, let me know if you want me to change some things.